### PR TITLE
fix(timer): prevent undo from duplicating saved intervals (Batch 2)

### DIFF
--- a/src/features/timer/TimerSync.tsx
+++ b/src/features/timer/TimerSync.tsx
@@ -59,7 +59,11 @@ export function TimerSync() {
               isBillable: true,
               isBilled: false,
             });
-            await emit('time-entry-saved');
+            // emit is informational only -- don't let event-bus failures cause a
+            // persistence rollback when the DB row already exists
+            emit('time-entry-saved').catch((err) => {
+              console.warn('Failed to emit time-entry-saved:', err);
+            });
             return entry.id;
           });
           if (stopped) {

--- a/src/features/timer/TimerSync.tsx
+++ b/src/features/timer/TimerSync.tsx
@@ -50,7 +50,7 @@ export function TimerSync() {
       } else if (action === 'stop') {
         try {
           const stopped = await atomicStop(async (interval) => {
-            await timeEntryService.create({
+            const entry = await timeEntryService.create({
               projectId: interval.projectId,
               startTime: interval.startTime,
               endTime: new Date().toISOString(),
@@ -60,6 +60,7 @@ export function TimerSync() {
               isBilled: false,
             });
             await emit('time-entry-saved');
+            return entry.id;
           });
           if (stopped) {
             uiLogger.debug('Saved time entry from widget stop');

--- a/src/features/timer/TimerView.tsx
+++ b/src/features/timer/TimerView.tsx
@@ -200,8 +200,9 @@ export function TimerView() {
           isBilled: false,
         };
         timeEntryLogger.debug('Creating time entry with data:', entryData);
-        await timeEntryService.create(entryData);
+        const entry = await timeEntryService.create(entryData);
         await emit('time-entry-saved');
+        return entry.id;
       });
 
       if (stopped) {
@@ -209,8 +210,11 @@ export function TimerView() {
           message: 'Timer stopped',
           action: {
             label: 'Undo',
-            onClick: () => {
-              undoStop();
+            onClick: async () => {
+              const undone = await undoStop();
+              if (!undone) {
+                addToast({ message: 'Could not undo, time entry may have been saved' });
+              }
             },
           },
           duration: 10000,

--- a/src/features/timer/TimerView.tsx
+++ b/src/features/timer/TimerView.tsx
@@ -201,7 +201,11 @@ export function TimerView() {
         };
         timeEntryLogger.debug('Creating time entry with data:', entryData);
         const entry = await timeEntryService.create(entryData);
-        await emit('time-entry-saved');
+        // emit is informational only -- don't let event-bus failures cause a
+        // persistence rollback when the DB row already exists
+        emit('time-entry-saved').catch((err) => {
+          console.warn('Failed to emit time-entry-saved:', err);
+        });
         return entry.id;
       });
 

--- a/src/hooks/useShortcuts.ts
+++ b/src/hooks/useShortcuts.ts
@@ -61,7 +61,11 @@ export function useShortcuts() {
                   isBillable: true,
                   isBilled: false,
                 });
-                await emit('time-entry-saved');
+                // emit is informational only -- don't let event-bus failures cause a
+                // persistence rollback when the DB row already exists
+                emit('time-entry-saved').catch((err) => {
+                  console.warn('Failed to emit time-entry-saved:', err);
+                });
                 return entry.id;
               });
               if (stopped) {

--- a/src/hooks/useShortcuts.ts
+++ b/src/hooks/useShortcuts.ts
@@ -52,7 +52,7 @@ export function useShortcuts() {
           if (currentTimerState !== 'idle') {
             try {
               const stopped = await timerAtomicStop(async (interval) => {
-                await timeEntryService.create({
+                const entry = await timeEntryService.create({
                   projectId: interval.projectId,
                   startTime: interval.startTime,
                   endTime: new Date().toISOString(),
@@ -62,6 +62,7 @@ export function useShortcuts() {
                   isBilled: false,
                 });
                 await emit('time-entry-saved');
+                return entry.id;
               });
               if (stopped) {
                 await showNotification('Timer Stopped', 'Time entry has been saved');

--- a/src/hooks/useTimerWithEffects.ts
+++ b/src/hooks/useTimerWithEffects.ts
@@ -78,7 +78,7 @@ export function useTimerWithEffects() {
    * the caller can show a user-visible error and retry.
    */
   const atomicStop = useCallback(
-    async (persistFn: (interval: StopResult) => Promise<void>) => {
+    async (persistFn: (interval: StopResult) => Promise<string>) => {
       const settings = await settingsService.load();
       const projectName = timerStore.projectName;
       const elapsedSeconds = timerStore.getElapsedSeconds();

--- a/src/stores/timerStore.ts
+++ b/src/stores/timerStore.ts
@@ -2,6 +2,7 @@
 
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
+import { emit } from '@tauri-apps/api/event';
 import { timeEntryService } from '../services';
 
 export type TimerState = 'idle' | 'running' | 'paused';
@@ -251,6 +252,10 @@ export const useTimerStore = create<TimerStore>()(
           } catch {
             return false;
           }
+          // notify UI subscribers that the persisted entries changed
+          emit('time-entry-saved').catch((err) => {
+            console.warn('Failed to emit time-entry-saved after undo:', err);
+          });
         }
 
         set({

--- a/src/stores/timerStore.ts
+++ b/src/stores/timerStore.ts
@@ -2,6 +2,7 @@
 
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
+import { timeEntryService } from '../services';
 
 export type TimerState = 'idle' | 'running' | 'paused';
 
@@ -17,6 +18,7 @@ interface LastStoppedState {
   projectColor: string;
   startTime: string;
   accumulatedPauseDuration: number;
+  timeEntryId?: string;
 }
 
 interface TimerStore {
@@ -48,9 +50,9 @@ interface TimerStore {
    * the running state is preserved and stoppingInFlight is cleared so the
    * caller can retry. Concurrent callers receive false immediately.
    */
-  atomicStop: (persistFn: (interval: StopResult) => Promise<void>) => Promise<boolean>;
+  atomicStop: (persistFn: (interval: StopResult) => Promise<string>) => Promise<boolean>;
   reset: () => void;
-  undoStop: () => boolean;
+  undoStop: () => Promise<boolean>;
   clearLastStopped: () => void;
 
   // Computed (not stored, but helper)
@@ -192,7 +194,7 @@ export const useTimerStore = create<TimerStore>()(
         set({ stoppingInFlight: true });
 
         try {
-          await persistFn(interval);
+          const timeEntryId = await persistFn(interval);
 
           // Persist succeeded: commit the state transition.
           // Store totalPauseDuration (not the pre-stop accumulatedPauseDuration) so
@@ -206,6 +208,7 @@ export const useTimerStore = create<TimerStore>()(
               projectColor: projectColor!,
               startTime: startTime!,
               accumulatedPauseDuration: totalPauseDuration,
+              timeEntryId,
             },
             state: 'idle',
             projectId: null,
@@ -238,9 +241,17 @@ export const useTimerStore = create<TimerStore>()(
         });
       },
 
-      undoStop: () => {
+      undoStop: async () => {
         const { lastStoppedState } = get();
         if (!lastStoppedState) return false;
+
+        if (lastStoppedState.timeEntryId) {
+          try {
+            await timeEntryService.delete(lastStoppedState.timeEntryId);
+          } catch {
+            return false;
+          }
+        }
 
         set({
           state: 'running',


### PR DESCRIPTION
## What

Bind timer undo to the time entry row persisted at stop time, so clicking Undo deletes the row before restoring running state. No more duplicate billable intervals if the user changes their mind right after stopping.

## Why

Audit finding **M-FF-APP-002** (Wave 3 canonical plan, batch `FF-APP-B2-P1`): in B1, `atomicStop` started persisting the time entry to SQLite before clearing running state. That fixed double-stop races but left a new gap: undo only reverted in-memory state without touching the DB row, so undoing a stop produced a row in the time-entries table that the timer no longer believed existed. Subsequent stops would create a second row for the same work interval.

## Files changed

- `src/stores/timerStore.ts` -- `lastStoppedState` now carries `timeEntryId: string | undefined`. `atomicStop` captures the row ID from `persistFn`'s return value and stores it. `undoStop` calls `timeEntryService.delete(timeEntryId)` before the `set()` that restores running state.
- `src/features/timer/TimerView.tsx` -- captures `undoStop`'s return value; surfaces a toast (`Could not undo, time entry may have been saved`) when undo fails.
- `src/features/timer/TimerSync.tsx` -- updated to pass `persistFn` returning the row ID.
- `src/hooks/useShortcuts.ts` -- same update for keyboard shortcut path.
- `src/hooks/useTimerWithEffects.ts` -- legacy wrapper preserved; new flow exposed via `atomicStop`.

## Acceptance criteria verified (auditor: PASS)

- [x] Clicking Undo after a successful stop never produces a duplicate billable interval. `undoStop` deletes the row by ID before restoring running state.
- [x] Timer state + DB state stay in sync after Undo. Delete-then-set sequence; if delete fails, `set()` never runs.
- [x] Undo failure surfaces error and keeps stopped state. `undoStop` returns `false` on delete failure; TimerView shows a toast.

## Verification

- `npx tsc --noEmit` exits 0.
- `npm test --run` exits 0; 9/9 tests pass.
- Em-dash scrub: 0 em-dashes in diff.

## Adversarial probes (auditor)

All four flagged as LOW or INFO with documented mitigations:

- Race between stop and undo creating partial state -- Undo button only renders after `atomicStop` commits `stopped` state; no user-triggerable race window.
- `persistFn` writes row but ID capture fails -- guaranteed by service contract (`timeEntryService.create` generates UUID pre-INSERT, throws on failure).
- Legacy `stop()` bypass -- `@deprecated`, no Undo toast surfaced on that path.
- Navigate away mid-undo -- Promise chain not cancelled by route change; SQLite delete completes via Tauri backend.

## Batch info

- Wave 3, phase batch `FF-APP-B2-P1`
- Finding: `M-FF-APP-002`
- Worktree: `FlowForge-react-WT-B2` (branch `fix/ff-app-batch-02-timer-undo-safety`, base `timesage-visual-refresh`)
- Implementer: Kimi-K2.6 via stdin pipe
- Auditor: Copilot CLI / Claude Sonnet 4.6 xhigh -> **VERDICT: PASS**

## Rollback

`git revert <merge-commit>` -- additive change to the lastStoppedState shape; the new `timeEntryId` field is optional so persisted state from before this patch is unaffected on upgrade.
